### PR TITLE
edit obtenerUsuario schema and resolver

### DIFF
--- a/db/resolvers.js
+++ b/db/resolvers.js
@@ -17,10 +17,8 @@ const crearToken = (usuario, secreta, expiresIn) => {
 
 const resolvers = {
   Query: {
-    obtenerUsuario: async (_, { token }) => {
-      const usuarioId = jwt.verify(token, process.env.SECRETA)
-
-      return usuarioId
+    obtenerUsuario: async (_, {}, ctx) => {
+      return ctx.usuario
     },
     obtenerProductos: async () => {
       try {

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -101,7 +101,7 @@ const typeDefs = gql`
   
   type Query {
     # Usuarios
-    obtenerUsuario(token: String!): Usuario
+    obtenerUsuario: Usuario
 
     # Productos
     obtenerProductos: [Producto]


### PR DESCRIPTION
Edit `obtenerUsuario` schema and resolver: 
- It's no needed to pass token because the context from Apollo has the user object 